### PR TITLE
Use streamStatus._dirty to track necessity of coreElementsChanged()

### DIFF
--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -219,7 +219,8 @@ def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
     # remove from original spanner bundle
     for sp in rm:
         spannerBundle.remove(sp)
-    p.coreElementsChanged()
+    if p.streamStatus._dirty:
+        p.coreElementsChanged()
     return p
 
 

--- a/music21/base.py
+++ b/music21/base.py
@@ -2467,7 +2467,8 @@ class Music21Object(prebase.ProtoM21Object):
         for s in self.sites.get():
             if hasattr(s, 'coreElementsChanged'):
                 # noinspection PyCallingNonCallable
-                s.coreElementsChanged(updateIsFlat=False, keepIndex=True)
+                if s.streamStatus._dirty:
+                    s.coreElementsChanged(updateIsFlat=False, keepIndex=True)
 
     def _getPriority(self):
         return self._priority
@@ -3592,6 +3593,7 @@ class Music21Object(prebase.ProtoM21Object):
         self.duration = mm.secondsToDuration(value)
         for s in self.sites.get(excludeNone=True):
             if self in s.elements:
+                s.streamStatus._dirty = True
                 s.coreElementsChanged()  # highest time is changed.
 
     seconds = property(_getSeconds, _setSeconds, doc='''

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -480,6 +480,7 @@ class StreamFreezer(StreamFreezeThawBase):
         streamObj._offsetDict = {}
         streamObj._elements = []
         streamObj._endElements = []
+        streamObj.streamStatus._dirty = True
         streamObj.coreElementsChanged()
 
     def findActiveStreamIdsInHierarchy(
@@ -777,14 +778,18 @@ class StreamThawer(StreamFreezeThawBase):
                 # works like a whole new hierarchy...  # no need for deepcopy
                 subSF = StreamThawer()
                 subSF.teardownSerializationScaffold(e._stream)
-                e._stream.coreElementsChanged()
+                if e._stream.streamStatus._dirty:
+                    e._stream.coreElementsChanged()
+                    assert False, "Never runs"
                 e._cache = {}
                 # for el in e._stream.flat:
                 #    print(el, el.offset, el.sites.siteDict)
             elif 'Spanner' in eClasses:
                 subSF = StreamThawer()
                 subSF.teardownSerializationScaffold(e.spannerStorage)
-                e.spannerStorage.coreElementsChanged()
+                if e.spannerStorage.streamStatus._dirty:
+                    e.spannerStorage.coreElementsChanged()
+                    assert False, "Never runs"
                 e._cache = {}
             elif e.isStream:
                 self.restoreStreamStatusClient(e)
@@ -795,7 +800,9 @@ class StreamThawer(StreamFreezeThawBase):
 
         # restore to whatever it was
         streamObj.autoSort = storedAutoSort
-        streamObj.coreElementsChanged()
+        if streamObj.streamStatus._dirty:
+            streamObj.coreElementsChanged()
+            assert False, "Never runs"
         _fixId(streamObj)
 
     def restoreElementsFromTuples(self, streamObj):

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -778,18 +778,12 @@ class StreamThawer(StreamFreezeThawBase):
                 # works like a whole new hierarchy...  # no need for deepcopy
                 subSF = StreamThawer()
                 subSF.teardownSerializationScaffold(e._stream)
-                if e._stream.streamStatus._dirty:
-                    e._stream.coreElementsChanged()
-                    assert False, "Never runs"
                 e._cache = {}
                 # for el in e._stream.flat:
                 #    print(el, el.offset, el.sites.siteDict)
             elif 'Spanner' in eClasses:
                 subSF = StreamThawer()
                 subSF.teardownSerializationScaffold(e.spannerStorage)
-                if e.spannerStorage.streamStatus._dirty:
-                    e.spannerStorage.coreElementsChanged()
-                    assert False, "Never runs"
                 e._cache = {}
             elif e.isStream:
                 self.restoreStreamStatusClient(e)
@@ -800,9 +794,6 @@ class StreamThawer(StreamFreezeThawBase):
 
         # restore to whatever it was
         streamObj.autoSort = storedAutoSort
-        if streamObj.streamStatus._dirty:
-            streamObj.coreElementsChanged()
-            assert False, "Never runs"
         _fixId(streamObj)
 
     def restoreElementsFromTuples(self, streamObj):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1207,7 +1207,8 @@ class HumdrumSpine:
         for el in streamIn:
             if 'Stream' in el.classes:
                 if currentMeasureNumber != 0 or currentMeasure:
-                    currentMeasure.coreElementsChanged()
+                    if currentMeasure.streamStatus._dirty:
+                        currentMeasure.coreElementsChanged()
                     # streamOut.append(currentMeasure)
                     streamOut.coreAppend(currentMeasure)
                 currentMeasure = el
@@ -1223,8 +1224,10 @@ class HumdrumSpine:
                     # streamOut.append(el)
                     streamOut.coreAppend(el)
         # update the most recent measure and the surrounding stream, then append the last
-        currentMeasure.coreElementsChanged()
-        streamOut.coreElementsChanged()
+        if currentMeasure.streamStatus._dirty:
+            currentMeasure.coreElementsChanged()
+        if streamOut.streamStatus._dirty:
+            streamOut.coreElementsChanged()
         if currentMeasure:
             streamOut.append(currentMeasure)
 
@@ -1451,7 +1454,8 @@ class DynamSpine(HumdrumSpine):
                     thisObject = MiscTandem(eventC)
             elif eventC.startswith('='):
                 if thisContainer is not None:
-                    thisContainer.coreElementsChanged()
+                    if thisContainer.streamStatus._dirty:
+                        thisContainer.coreElementsChanged()
                     self.stream.coreAppend(thisContainer)
                 thisContainer = hdStringToMeasure(eventC)
             elif eventC.startswith('!'):
@@ -1823,7 +1827,8 @@ class SpineCollection:
         Insert all the spines into newStream that should be
         inserted into thisSpine at insertionPoint.
         '''
-        newStream.coreElementsChanged()  # update highestTime
+        if newStream.streamStatus._dirty:
+            newStream.coreElementsChanged()  # update highestTime
         startPoint = newStream.highestTime
         childrenToInsert = thisSpine.childSpineInsertPoints[insertionPoint]
         voiceNumber = 0

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -719,9 +719,11 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
 
             thisPage.coreAppend(thisSystem)
         thisPage.systemEnd = systemNumber
-        thisPage.coreElementsChanged()
+        if thisPage.streamStatus._dirty:
+            thisPage.coreElementsChanged()
         scoreLists.coreAppend(thisPage)
-    scoreLists.coreElementsChanged()
+    if scoreLists.streamStatus._dirty:
+        scoreLists.coreElementsChanged()
     return scoreLists
 
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1836,7 +1836,8 @@ def midiTrackToStream(
         n.midiTickStart = notes[i][0][0]
         s.coreInsert(o, n)
 
-    s.coreElementsChanged()
+    if s.streamStatus._dirty:
+        s.coreElementsChanged()
     # quantize to nearest 16th
     if quantizePost:
         if 'quarterLengthDivisors' in keywords:
@@ -1977,7 +1978,8 @@ def conductorStream(s: stream.Stream) -> stream.Part:
                 conductorPart.coreInsert(o, el)
             lastOffset = o
 
-    conductorPart.coreElementsChanged()
+    if conductorPart.streamStatus._dirty:
+        conductorPart.coreElementsChanged()
 
     # Defaults
     if not conductorPart.getElementsByClass('MetronomeMark'):

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -371,7 +371,8 @@ class PartTranslator:
                     + f'an exception was raised: \n{tracebackMessage}')
 
         p = self.p
-        p.coreElementsChanged()
+        if p.streamStatus._dirty:
+            p.coreElementsChanged()
         fixPickupMeasure(p)
         p.makeBeams(inPlace=True)
         p.makeAccidentals(inPlace=True)
@@ -536,7 +537,8 @@ class PartTranslator:
 
         # create a new measure or copy a past measure
         if isSingleMeasureCopy:  # if not a range
-            p.coreElementsChanged()
+            if p.streamStatus._dirty:
+                p.coreElementsChanged()
             m, self.kCurrent = _copySingleMeasure(t, p, self.kCurrent)
             p.coreAppend(m)
             self.lastMeasureNumber = m.number
@@ -546,7 +548,8 @@ class PartTranslator:
                 self.previousRn = romans[-1]
 
         elif isMultipleMeasureCopy:
-            p.coreElementsChanged()
+            if p.streamStatus._dirty:
+                p.coreElementsChanged()
             measures, self.kCurrent = _copyMultipleMeasures(t, p, self.kCurrent)
             p.append(measures)  # appendCore does not work with list
             self.lastMeasureNumber = measures[-1].number
@@ -670,7 +673,8 @@ class PartTranslator:
         if self.tsCurrent is not None:
             self.previousRn.quarterLength = (self.tsCurrent.barDuration.quarterLength
                                                 - self.currentOffsetInMeasure)
-        m.coreElementsChanged()
+        if m.streamStatus._dirty:
+            m.coreElementsChanged()
         return m
 
     def translateSingleMeasureAtom(self, a, m, *, isLastAtomInMeasure=False):

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -447,7 +447,8 @@ class Spanner(base.Music21Object):
                 #    already found in the SpannerStorage stream of spanner %s;
                 #    this may not be an error.''' % (c, self)])
 
-        self.spannerStorage.coreElementsChanged()
+        if self.spannerStorage.streamStatus._dirty:
+            self.spannerStorage.coreElementsChanged()
 
     def hasSpannedElement(self, spannedElement):
         '''

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -795,11 +795,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # there is no new clef - suppresses the clef of a stream
             return
         self.insert(0.0, clefObj)
-        # for some reason needed to make sure that sorting of Clef happens before TimeSignature
-        # TODO: Test if this can be deleted...
-        if self.streamStatus._dirty:
-            self.coreElementsChanged()
-            assert False, 'never runs'
 
     @property
     def timeSignature(self):
@@ -5111,9 +5106,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         self.shiftElements(self.offset)
         self.offset = 0.0
-        if self.streamStatus._dirty:
-            self.coreElementsChanged()
-            assert False, 'never runs'
 
     # -------------------------------------------------------------------------
     # utilities for creating large numbers of elements
@@ -6713,10 +6705,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # Recurse rather than depend on the containers being Measures
             # https://github.com/cuthbertLab/music21/issues/266
             returnObj.remove(nTarget, recurse=True)
-
-        if returnObj.streamStatus._dirty:
-            returnObj.coreElementsChanged()
-            assert False
 
         if retainContainers:
             return returnObj
@@ -8364,9 +8352,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         for e in returnObj.recurse().getElementsNotOfClass('Stream'):
             e.duration = e.duration.augmentOrDiminish(amountToScale)
 
-        if returnObj.streamStatus._dirty:
-            returnObj.coreElementsChanged()
-            assert False, 'never runs'
         if inPlace is not True:
             return returnObj
 
@@ -8419,9 +8404,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         returnObj.scaleOffsets(amountToScale=amountToScale, anchorZero='lowest',
                                anchorZeroRecurse=None, inPlace=True)
         returnObj.scaleDurations(amountToScale=amountToScale, inPlace=True)
-        if self.streamStatus._dirty:
-            returnObj.coreElementsChanged()
-            assert False
+
         # do not need to call elements changed, as called in sub methods
         return returnObj
 
@@ -8739,9 +8722,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # call on component measures
             for m in returnObj.getElementsByClass('Measure'):
                 m.sliceByGreatestDivisor(addTies=addTies, inPlace=True)
-            if returnObj.streamStatus._dirty:
-                returnObj.coreElementsChanged()
-                assert False, 'never runs'
             return returnObj  # exit
 
         uniqueQuarterLengths = []
@@ -8758,9 +8738,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         returnObj.sliceByQuarterLengths(quarterLengthList=[divisor],
                                         target=None, addTies=addTies, inPlace=True)
 
-        if returnObj.streamStatus._dirty:
-            returnObj.coreElementsChanged()
-            assert False, 'never runs'
         if not inPlace:
             return returnObj
 
@@ -13391,12 +13368,6 @@ class Score(Stream):
                                inPlace=True,
                                bestClef=bestClef,
                                **subroutineKeywords)
-            # note: while the local-streams have updated their caches, the
-            # containing score has an out-of-date cache of flat.
-            # thus, must call elements changed
-            if returnStream.streamStatus._dirty:
-                returnStream.coreElementsChanged()
-                assert False, 'never runs'
         else:  # call the base method
             super(Score, returnStream).makeNotation(meterStream=meterStream,
                                                     refStreamOrTimeRange=refStreamOrTimeRange,

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -11036,9 +11036,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         # Now fix measure numbers given the saved information
         returnObj._fixMeasureNumbers(deletedMeasures, insertedMeasures)
 
-        # have to clear cached variants, as they are no longer the same
-        if returnObj.streamStatus._dirty:
-            returnObj.coreElementsChanged()
         if not inPlace:
             return returnObj
         else:
@@ -11586,6 +11583,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
                     elementOffset = e.getOffsetBySite(returnObj)
                     returnObj.setElementOffset(e, elementOffset + shiftDur)
+
+        # ran setElementOffset
+        returnObj.coreElementsChanged()
 
         if inPlace is True:
             return

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -2502,9 +2502,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         # after shifting all the necessary elements, append new ones
         # these will not be in order
         self.insert(offsetOrItemOrList, itemOrNone)
-        # call this as elements are now out of order
-        if self.streamStatus._dirty:
-            self.coreElementsChanged()
 
     # --------------------------------------------------------------------------
     # searching and replacing routines
@@ -10583,8 +10580,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     returnObj.coreInsert(shiftOffset + e.getOffsetBySite(v), e)
                 returnObj.remove(v)
 
-        if returnObj.streamStatus._dirty:
-            returnObj.coreElementsChanged()
         if not inPlace:
             return returnObj
         else:

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -164,7 +164,7 @@ class StreamIterator(prebase.ProtoM21Object):
             try:
                 e = self.srcStreamElements[self.index - 1]
             except IndexError:
-                # this may happen in the number of elements has changed
+                # this may happen if the number of elements has changed
                 continue
 
             if self.matchesFilters(e) is False:
@@ -251,6 +251,10 @@ class StreamIterator(prebase.ProtoM21Object):
         Traceback (most recent call last):
         AttributeError: 'StreamIterator' object has no attribute 'asdf'
         '''
+        # Prevent infinite loop
+        if attr == 'srcStream':
+            return
+
         if not hasattr(self.srcStream, attr):
             # original stream did not have the attribute, so new won't; but raise on iterator.
             raise AttributeError(f'{self.__class__.__name__!r} object has no attribute {attr!r}')

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -619,10 +619,6 @@ def makeMeasures(
     for sp in spannerBundleAccum:
         post.append(sp)
 
-    if post.streamStatus._dirty:
-        post.coreElementsChanged()
-        assert False, 'never runs'
-
     # clean up temporary streams to avoid extra site accumulation
     del srcObj
 
@@ -1179,10 +1175,6 @@ def makeTies(
         mCount += 1
     del measureStream  # clean up unused streams
 
-    # changes elements
-    if returnObj.streamStatus._dirty:
-        returnObj.coreElementsChanged()
-        assert False, 'never runs'
     if not inPlace:
         return returnObj
     else:

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -522,6 +522,8 @@ def makeMeasures(
             v = stream.Voice()
             v.id = voiceIndex  # id is voice index, starting at 0
             m.coreInsert(0, v)
+        if m.streamStatus._dirty:
+            m.coreElementsChanged()
 
         # avoid an infinite loop
         if thisTimeSignature.barDuration.quarterLength == 0:
@@ -534,6 +536,8 @@ def makeMeasures(
             break  # if length of this measure exceeds last offset
         else:
             measureCount += 1
+
+    post.coreElementsChanged()
 
     # cache information about each measure (we used to do this once per element...
     postLen = len(post)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -619,7 +619,9 @@ def makeMeasures(
     for sp in spannerBundleAccum:
         post.append(sp)
 
-    post.coreElementsChanged()
+    if post.streamStatus._dirty:
+        post.coreElementsChanged()
+        assert False, 'never runs'
 
     # clean up temporary streams to avoid extra site accumulation
     del srcObj
@@ -642,6 +644,7 @@ def makeMeasures(
         # with Measures created above
         s._elements = []
         s._endElements = []
+        s.streamStatus._dirty = True
         s.coreElementsChanged()
         if post.isSorted:
             postSorted = post
@@ -1177,7 +1180,9 @@ def makeTies(
     del measureStream  # clean up unused streams
 
     # changes elements
-    returnObj.coreElementsChanged()
+    if returnObj.streamStatus._dirty:
+        returnObj.coreElementsChanged()
+        assert False, 'never runs'
     if not inPlace:
         return returnObj
     else:

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -3013,6 +3013,7 @@ class Test(unittest.TestCase):
             # try the same with scrambled elements
             sProc = copy.deepcopy(s)
             random.shuffle(sProc._elements)
+            sProc.streamStatus._dirty = True
             sProc.coreElementsChanged()
 
             self.assertEqual(sProc.highestOffset, 12)


### PR DESCRIPTION
**Motivation**
`setElementOffset()` appears to require `coreElementsChanged()` to be run afterward. This isn't mentioned in the docs, and it isn't observed everywhere in the codebase, possibly causing bugs.

Most of those bugs are being caught with prophylactic calls to `coreElementsChanged()` further downstream. However, calling this unnecessarily is a performance problem (and defeats the original purpose of the core methods). This PR uses the existing attribute `streamStatus._dirty` to track the necessity of calling `coreElementsChanged` (and this was how I discovered that setElementOffset was dangerous).

**Steps to reproduce**

```
bachIn = corpus.parse('bach/bwv324.xml')
unused_slice = bachIn.measure(2)
bachIn.measure(1).parts[0].show('text')
```

**Expected vs. actual behavior**
An example (I take it) of an unnecessary call to `coreElementsChanged()`: the sheer fact of taking a slice with `measure()` causes the `SystemLayout` object to move:

BEFORE slicing measure 2
```
{0.0} <music21.instrument.Instrument 'P1: Soprano: '>
{0.0} <music21.stream.Measure 1 offset=0.0>
    {0.0} <music21.layout.SystemLayout>
    {0.0} <music21.clef.TrebleClef>
    {0.0} <music21.key.Key of e minor>
    {0.0} <music21.meter.TimeSignature 4/4>
    {0.0} <music21.note.Note B>
    {2.0} <music21.note.Note D>
```

AFTER slicing measure 2
```
{0.0} <music21.instrument.Instrument 'P1: Soprano: '>
{0.0} <music21.stream.Measure 1 offset=0.0>
    {0.0} <music21.clef.TrebleClef>
    {0.0} <music21.key.Key of e minor>
    {0.0} <music21.meter.TimeSignature 4/4>
    {0.0} <music21.layout.SystemLayout>
    {0.0} <music21.note.Note B>
    {2.0} <music21.note.Note D>
```