### PR TITLE
Make more multipart streams eligible to be brailled

### DIFF
--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -265,7 +265,8 @@ Barline final ⠣⠅
         from music21.braille.translate import objectToBraille
         verdi = corpus.parse('verdi/laDonnaEMobile')
         x = objectToBraille(verdi, debug=True)
-        y = '''---begin grand segment---
+        y = '''⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠇⠁⠠⠙⠕⠝⠝⠁⠠⠑⠠⠍⠕⠃⠊⠇⠑⠲⠍⠭⠇
+---begin grand segment---
 <music21.braille.segment BrailleGrandSegment>
 ===
 Measure 1 Right, Signature Grouping 1:


### PR DESCRIPTION
Previously, piano music could only be exported bar-over-bar if the score contained one and only one grand staff, i.e. not a full score.