### PR TITLE
Fix KeyAnalyzer bug with 0-indexing vs. 1-indexing

### DIFF
--- a/music21/analysis/floatingKey.py
+++ b/music21/analysis/floatingKey.py
@@ -38,7 +38,7 @@ class KeyAnalyzer:
     >>> ka = analysis.floatingKey.KeyAnalyzer(b)
     >>> ka.windowSize = 2  # chorale uses quick key changes
     >>> ka.run()  # first measure is the pickup
-    [<music21.key.Key of A major>, <music21.key.Key of A major>, <music21.key.Key of A major>,
+    [<music21.key.Key of A major>, <music21.key.Key of A major>, <music21.key.Key of f# minor>,
      <music21.key.Key of f# minor>, <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
      <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
      <music21.key.Key of f# minor>, <music21.key.Key of f# minor>]
@@ -46,19 +46,28 @@ class KeyAnalyzer:
     Raw analysis (no smoothing):
 
     >>> ka.getRawKeyByMeasure()
-    [<music21.key.Key of A major>, <music21.key.Key of E major>, <music21.key.Key of A major>,
-     <music21.key.Key of f# minor>, <music21.key.Key of E major>, <music21.key.Key of A major>,
-     <music21.key.Key of b minor>, <music21.key.Key of C# major>,
-     <music21.key.Key of F# major>, <music21.key.Key of b minor>]
+    [<music21.key.Key of f# minor>, <music21.key.Key of A major>, <music21.key.Key of f# minor>,
+     <music21.key.Key of f# minor>, <music21.key.Key of E major>, <music21.key.Key of f# minor>,
+     <music21.key.Key of f# minor>, <music21.key.Key of C# major>,
+     <music21.key.Key of B major>, <music21.key.Key of B major>]
 
     Major smoothing...
 
     >>> ka.windowSize = ka.numMeasures // 2
-    >>> ka.run()  # only the pickup seems to be in A major by this approach
-    [<music21.key.Key of A major>, <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
+    >>> ka.run()  # nothing seems to be in A major by this approach
+    [<music21.key.Key of f# minor>, <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
      <music21.key.Key of f# minor>, <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
-     <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
-     <music21.key.Key of f# minor>, <music21.key.Key of f# minor>]
+     <music21.key.Key of f# minor>, <music21.key.Key of f# minor>, <music21.key.Key of f# minor>,
+     <music21.key.Key of f# minor>]
+
+    Fixed in v.7 -- analysis now incorporates final measures in pieces without pickup measures:
+
+    >>> tiny = converter.parse('tinyNotation: c1 e1 g1 c1 d-4 d-4 d-4 d-4')
+    >>> ka = analysis.floatingKey.KeyAnalyzer(tiny)
+    >>> ka.windowSize = 1
+    >>> ka.run()  # This previous only gave four elements: am, CM, CM, CM
+    [<music21.key.Key of a minor>, <music21.key.Key of C major>, <music21.key.Key of C major>,
+     <music21.key.Key of C major>, <music21.key.Key of b- minor>]
     '''
     def __init__(self, s=None):
         if s is None:
@@ -70,11 +79,13 @@ class KeyAnalyzer:
 
         self.weightAlgorithm = divide
         if s.hasPartLikeStreams():
-            p = s.parts.first()
+            p = s.iter.parts.first()
         else:
             p = s
-        self.numMeasures = len(p.getElementsByClass('Measure'))  # could be wrong for endings, etc.
-        if self.numMeasures == 0:
+        self.measures = p.getElementsByClass('Measure')  # could be wrong for endings, etc.
+        # shim for backwards-compatibility
+        self.numMeasures = len(self.measures)
+        if not self.measures:
             raise FloatingKeyException("Stream must have Measures inside it")
 
     def run(self):
@@ -83,9 +94,8 @@ class KeyAnalyzer:
 
     def getRawKeyByMeasure(self):
         keyByMeasure = []
-        for i in range(self.numMeasures):
-            m = self.stream.measure(i)
-            if m is None or not m.recurse().notes:
+        for m in self.measures:
+            if not m.recurse().notes:
                 k = None
             else:
                 k = m.analyze('key')
@@ -93,15 +103,22 @@ class KeyAnalyzer:
         self.rawKeyByMeasure = keyByMeasure
         return keyByMeasure
 
-    def getInterpretationByMeasure(self, mNumber):
+    def getInterpretationByMeasure(self, mNumber, anacrusis: bool = True):
         '''
         Returns a dictionary of interpretations for the measure.
+
+        New in v.7 = if anacrusis is True (default), mNumber will be presumed
+        to be 0-indexed. This behavior may change in the future.
         '''
         if mNumber in self._interpretationMeasureDict:
             return self._interpretationMeasureDict[mNumber]  # CACHE
         if not self.rawKeyByMeasure:
             self.getRawKeyByMeasure()
-        mk = self.rawKeyByMeasure[mNumber]
+        if anacrusis:
+            i = mNumber
+        else:
+            i = mNumber - 1
+        mk = self.rawKeyByMeasure[i]
         if mk is None:
             return None
         # noinspection PyDictCreation
@@ -116,15 +133,21 @@ class KeyAnalyzer:
         smoothedKeysByMeasure = []
         algorithm = self.weightAlgorithm
 
-        for i in range(self.numMeasures):
-            baseInterpretations = self.getInterpretationByMeasure(i)
+        maxMNum: int = len(self.measures)
+        anacrusis: bool = False
+        if self.measures.first().number == 0:
+            anacrusis = True
+            maxMNum -= 1
+        for m in self.measures:
+            i = m.number
+            baseInterpretations = self.getInterpretationByMeasure(i, anacrusis=anacrusis)
             if baseInterpretations is None:
                 continue
             for j in range(-1 * self.windowSize, self.windowSize + 1):  # -2, -1, 0, 1, 2 etc.
                 mNum = i + j
-                if mNum < 0 or mNum >= self.numMeasures or mNum == i:
+                if mNum < 0 or mNum > maxMNum or mNum == i or (not anacrusis and mNum == 0):
                     continue
-                newInterpretations = self.getInterpretationByMeasure(mNum)
+                newInterpretations = self.getInterpretationByMeasure(mNum, anacrusis=anacrusis)
                 if newInterpretations is not None:
                     for k in baseInterpretations:
                         coefficient = algorithm(newInterpretations[k], j)


### PR DESCRIPTION
measure numbers were assumed to be 0-indexed, but accessed with .measure(), which gets the actual measure numbers, so this only worked exactly right for pieces with pickup measures, like the Bach chorale in the doctest.