### PR TITLE
Avoid leaving malformed StaffGroups in cases where ScoreExporter is used directly

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 3)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 4)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.3'
+'7.0.4'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3808,7 +3808,7 @@ class MeasureParser(XMLParserBase):
         # add a reference of this note to this spanner
         if target is not None:
             su.addSpannedElements(target)
-        # environLocal.printDebug(['adding n', n, id(n), 'su.getSpannedElements',
+        # environLocal.printDebug(['adding n', target, id(target), 'su.getSpannedElements',
         #     su.getSpannedElements(), su.getSpannedElementIds()])
         if mxObj.get('type') == 'stop':
             su.completeStatus = True

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13930,8 +13930,10 @@ class SpannerStorage(Stream):
                 allDerived: bool = True) -> None:
         '''
         Overrides :meth:`~music21.stream.Stream.replace` in order to check first
-        whether `replacement` already exists in `self`. If, so delete `target` from
+        whether `replacement` already exists in `self`. If so, delete `target` from
         `self` and return; otherwise call the superclass method.
+
+        New in v7.
         '''
         # Does not perform a recursive search, but shouldn't need to
         if replacement in self:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13929,7 +13929,7 @@ class SpannerStorage(Stream):
                 recurse: bool = False,
                 allDerived: bool = True) -> None:
         '''
-        Overrides :meth:`~music21.stream.base.replace` in order to check first
+        Overrides :meth:`~music21.stream.Stream.replace` in order to check first
         whether `replacement` already exists in `self`. If, so delete `target` from
         `self` and return; otherwise call the superclass method.
         '''

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2108,7 +2108,7 @@ class Test(unittest.TestCase):
         s.replace(n4, n1)
         self.assertEqual([s[0], s[1]], [n3, n1])
 
-        error_msg = f'no replacement performed, as {n3} already in {s}'
+        error_msg = f'{n3} already in {s}'
         with self.assertRaises(StreamException, msg=error_msg):
             s.replace(n4, n3)
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1181,6 +1181,9 @@ class Test(unittest.TestCase):
         stripped = s.stripTies(inPlace=False)
         sn1 = stripped.flat.notes[0]
 
+        self.assertEqual(len(stripped.spanners[0]), 1)
+        self.assertEqual(len(stripped.spanners[1]), 1)
+
         self.assertTrue(stripped.spanners[0].isFirst(sn1))
         self.assertTrue(stripped.spanners[0].isLast(sn1))
         self.assertTrue(stripped.spanners[1].isFirst(sn1))
@@ -2104,6 +2107,10 @@ class Test(unittest.TestCase):
 
         s.replace(n4, n1)
         self.assertEqual([s[0], s[1]], [n3, n1])
+
+        error_msg = f'no replacement performed, as {n3} already in {s}'
+        with self.assertRaises(StreamException, msg=error_msg):
+            s.replace(n3, n1)
 
     def testReplaceA1(self):
         sBach = corpus.parse('bach/bwv324.xml')

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2110,7 +2110,7 @@ class Test(unittest.TestCase):
 
         error_msg = f'no replacement performed, as {n3} already in {s}'
         with self.assertRaises(StreamException, msg=error_msg):
-            s.replace(n3, n1)
+            s.replace(n4, n3)
 
     def testReplaceA1(self):
         sBach = corpus.parse('bach/bwv324.xml')


### PR DESCRIPTION
Side effects were left on the input stream in a workaround to get `<part-group type="stop" />` written
stream.write() was not affected -- just advanced usage of calling ScoreExporter directly, since stream.write() makes a deepcopy.