### PR TITLE
coveralls bug: this diff will cause an existing covered line to lose coverage

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 6, 'a1')  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 'coveralls')  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.6a1'
+'7.0.coveralls'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":


### PR DESCRIPTION
This diff will cause line 49 of `_version.py` to lose coverage in virtue of the version tuple having a length of 3, not 4.